### PR TITLE
CM-26337 - Add the context menu for tree view items

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
   "main": "./dist/extension.js",
   "contributes": {
     "menus": {
+      "commandPalette": [
+        {
+          "command": "cycode.openViolationInFileFromTreeItemContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "cycode.openViolationPanelFromTreeItemContextMenu",
+          "when": "false"
+        }
+      ],
       "explorer/context": [
         {
           "when": "explorerResourceIsFolder",
@@ -51,6 +61,22 @@
           "command": "cycode.scaScan",
           "when": "viewItem == SCA",
           "group": "inline"
+        },
+        {
+          "command": "cycode.scan",
+          "when": "view == scan.treeView && viewItem =~ /^Secrets/"
+        },
+        {
+          "command": "cycode.scaScan",
+          "when": "view == scan.treeView && viewItem =~ /^SCA/"
+        },
+        {
+          "command": "cycode.openViolationInFileFromTreeItemContextMenu",
+          "when": "view == scan.treeView && viewItem =~ /-vulnerability$/"
+        },
+        {
+          "command": "cycode.openViolationPanelFromTreeItemContextMenu",
+          "when": "view == scan.treeView && viewItem == SCA-vulnerability"
         }
       ]
     },
@@ -109,18 +135,6 @@
         "title": "Cycode: Authenticate with service"
       },
       {
-        "command": "cycode.auth.check",
-        "title": "Cycode: Auth Check"
-      },
-      {
-        "command": "cycode.install",
-        "title": "Cycode: Install CLI with pip"
-      },
-      {
-        "command": "cycode.uninstall",
-        "title": "Cycode: Uninstall cycode CLI"
-      },
-      {
         "command": "cycode.openSettings",
         "title": "Cycode: Open Cycode settings",
         "icon": "$(settings-view-bar-icon)"
@@ -129,6 +143,14 @@
         "command": "cycode.openMainMenu",
         "title": "Cycode: Open main menu",
         "icon": "$(home)"
+      },
+      {
+        "command": "cycode.openViolationInFileFromTreeItemContextMenu",
+        "title": "Show violation in the file"
+      },
+      {
+        "command": "cycode.openViolationPanelFromTreeItemContextMenu",
+        "title": "Open violation details"
       }
     ],
     "viewsContainers": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -282,6 +282,20 @@ function initCommands(
     }
   );
 
+  const onOpenViolationInFileFromTreeItemContextMenuCommand = vscode.commands.registerCommand(
+    VscodeCommands.OpenViolationInFileFromTreeItemContextMenu,
+    async (item: TreeViewItem) => {
+      vscode.commands.executeCommand(VscodeCommands.OpenViolationInFile, item.fullFilePath, item.vulnerability?.lineNumber);
+    }
+  );
+
+  const onOpenViolationPanelFromTreeItemContextMenuCommand = vscode.commands.registerCommand(
+    VscodeCommands.OpenViolationPanelFromTreeItemContextMenu,
+    async (item: TreeViewItem) => {
+      vscode.commands.executeCommand(VscodeCommands.OpenViolationPanel, item.vulnerability?.detectionType, item.vulnerability?.detection);
+    }
+  );
+
   const openViolationInFileCommand = vscode.commands.registerCommand(
     VscodeCommands.OpenViolationInFile,
     async (fullFilePath: string, lineNumber: number) => {
@@ -396,6 +410,8 @@ function initCommands(
     authCommand,
     authCheckCommand,
     onTreeItemClickCommand,
+    onOpenViolationInFileFromTreeItemContextMenuCommand,
+    onOpenViolationPanelFromTreeItemContextMenuCommand,
     openViolationInFileCommand,
     openViolationPanel,
     installCommand,

--- a/src/providers/tree-view/item.ts
+++ b/src/providers/tree-view/item.ts
@@ -6,12 +6,14 @@ import { TreeViewDisplayedData } from './types';
 interface TreeViewItemOptions {
   title: string;
   collapsibleState: vscode.TreeItemCollapsibleState;
+  vulnerability?: TreeViewDisplayedData;
   vulnerabilities?: TreeViewDisplayedData[];
   scanSectionType?: ScanType;
   customIconPath?: string;
   description?: string;
   fullFilePath?: string;
   command?: vscode.Command;
+  contextValue?: string;
 }
 
 export class TreeViewItem extends vscode.TreeItem {
@@ -20,6 +22,7 @@ export class TreeViewItem extends vscode.TreeItem {
   public scanSectionType: ScanType | undefined;
   public fullFilePath: string | undefined;
   public vulnerabilities: TreeViewDisplayedData[] | undefined;
+  public vulnerability: TreeViewDisplayedData | undefined;
 
   constructor(options: TreeViewItemOptions) {
     super(options.title, options.collapsibleState);
@@ -27,11 +30,16 @@ export class TreeViewItem extends vscode.TreeItem {
     // vscode
     this.tooltip = options.title;
     this.command = options.command;
-    this.contextValue = options.scanSectionType;
+    this.contextValue = options.contextValue || options.scanSectionType;
 
     // custom
-    this.scanSectionType = options.scanSectionType;
     this.fullFilePath = options.fullFilePath;
+
+    // section tree item
+    this.scanSectionType = options.scanSectionType;
+    // detection tree item
+    this.vulnerability = options.vulnerability;
+    // file tree item
     this.vulnerabilities = options.vulnerabilities;
 
     if (options.customIconPath) {

--- a/src/providers/tree-view/provider.ts
+++ b/src/providers/tree-view/provider.ts
@@ -64,6 +64,7 @@ export class TreeViewDataProvider
               collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
               vulnerabilities: scanResult.vulnerabilities,
               fullFilePath: scanResult.fullFilePath,
+              contextValue: element.scanSectionType,
             })
         )
       );
@@ -127,9 +128,12 @@ const _createSeveritySortedTreeViewItems = (treeViewItem: TreeViewItem): TreeVie
 
       sortedVulnerabilities.push(new TreeViewItem({
         title: vulnerability.title,
+        vulnerability: vulnerability,
         collapsibleState: vscode.TreeItemCollapsibleState.None,
         customIconPath: getSeverityIconPath(severityFirstLetter),
-        command: openFileCommand
+        fullFilePath: treeViewItem.fullFilePath,
+        command: openFileCommand,
+        contextValue: `${treeViewItem.contextValue}-vulnerability`,
       }));
     });
   });

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -10,7 +10,9 @@ export enum VscodeCommands {
   ShowProblemsTab = "workbench.action.problems.focus",
   ShowCycodeView = "workbench.view.extension.cycode",
   AuthCheck = "cycode.auth.check",
-  OpenViolationInFile = "openViolationInFile",
-  OpenViolationPanel = "openViolationPanel",
-  OnTreeItemClick = "onTreeItemClick",
+  OpenViolationInFile = "cycode.openViolationInFile",
+  OpenViolationPanel = "cycode.openViolationPanel",
+  OnTreeItemClick = "cycode.onTreeItemClick",
+  OpenViolationInFileFromTreeItemContextMenu = "cycode.openViolationInFileFromTreeItemContextMenu",
+  OpenViolationPanelFromTreeItemContextMenu = "cycode.openViolationPanelFromTreeItemContextMenu",
 }


### PR DESCRIPTION
<img width="452" alt="image" src="https://github.com/cycodehq-public/vscode-extension/assets/15520314/bf86950e-daf0-47d6-9741-a80074283550">

`Cycode:` prefix because reuse of already existing command that displayed also here:

<img width="629" alt="image" src="https://github.com/cycodehq-public/vscode-extension/assets/15520314/4b39d163-3616-4612-baaa-3a157f9afd0a">

to remove this prefix we should create a duplicate of the command with a different title. should we? 
