### PR TITLE
CM-35961 - Leave "Open violation card" as only one quick fix action

### DIFF
--- a/src/panels/violation/violation-panel.ts
+++ b/src/panels/violation/violation-panel.ts
@@ -55,12 +55,12 @@ const _onDidReceiveMessage = async (message: Record<string, string>) => {
     return;
   }
 
-  const detection = scanResultsService.getDetectionById(message.uniqueDetectionId);
-  if (!detection) {
+  const scanResult = scanResultsService.getDetectionById(message.uniqueDetectionId);
+  if (!scanResult) {
     return;
   }
 
-  const ideData = await getSecretDetectionIdeData(detection as SecretDetection);
+  const ideData = await getSecretDetectionIdeData(scanResult.detection as SecretDetection);
 
   vscode.commands.executeCommand(
       VscodeCommands.IgnoreCommandId,

--- a/src/providers/code-actions/CodeActions.ts
+++ b/src/providers/code-actions/CodeActions.ts
@@ -13,15 +13,15 @@ export class CycodeActions implements vscode.CodeActionProvider {
   ];
 
   provideCodeActions(
-      document: vscode.TextDocument,
-      range: vscode.Range | vscode.Selection,
+      _document: vscode.TextDocument,
+      _range: vscode.Range | vscode.Selection,
       context: vscode.CodeActionContext
   ): vscode.CodeAction[] {
     const aggregatedDiagnostics = aggregateDiagnosticsByCode(context.diagnostics);
 
     const codeActions: vscode.CodeAction[] = [];
     for (const [diagnosticCode, diagnostics] of aggregatedDiagnostics.entries()) {
-      codeActions.push(...this.createCodeActions(diagnosticCode, diagnostics, document, range));
+      codeActions.push(...this.createCodeActions(diagnosticCode, diagnostics));
     }
 
     return this.getUniqueCodeActions(codeActions);
@@ -30,19 +30,17 @@ export class CycodeActions implements vscode.CodeActionProvider {
   private createCodeActions(
       rawDiagnosticCode: string,
       diagnostics: vscode.Diagnostic[],
-      document: vscode.TextDocument,
-      range: vscode.Range | vscode.Selection,
   ) {
     const diagnosticCode = DiagnosticCode.fromString(rawDiagnosticCode);
     switch (diagnosticCode.scanType) {
       case ScanType.Secrets:
-        return createSecretCommandCodeActions(document, range, diagnostics, diagnosticCode);
+        return createSecretCommandCodeActions(diagnostics, diagnosticCode);
       case ScanType.Sca:
-        return createScaCommandCodeActions(document, diagnostics, diagnosticCode);
+        return createScaCommandCodeActions(diagnostics, diagnosticCode);
       case ScanType.Iac:
-        return createIacCommandCodeActions(document, diagnostics, diagnosticCode);
+        return createIacCommandCodeActions(diagnostics, diagnosticCode);
       case ScanType.Sast:
-        return createSastCommandCodeActions(document, diagnostics, diagnosticCode);
+        return createSastCommandCodeActions(diagnostics, diagnosticCode);
       default:
         return [];
     }

--- a/src/providers/code-actions/iacCodeActions.ts
+++ b/src/providers/code-actions/iacCodeActions.ts
@@ -1,15 +1,12 @@
 import * as vscode from 'vscode';
 import {DiagnosticCode} from '../../services/common';
-import {createIgnorePathAction, createIgnoreRuleAction, createOpenViolationCardAction} from './commonActions';
+import {createOpenViolationCardAction} from './commonActions';
 
 export const createCommandCodeActions = (
-    document: vscode.TextDocument,
     diagnostics: vscode.Diagnostic[],
     diagnosticCode: DiagnosticCode,
 ): vscode.CodeAction[] => {
   return [
     createOpenViolationCardAction(diagnostics, diagnosticCode),
-    createIgnoreRuleAction(diagnostics, diagnosticCode, document),
-    createIgnorePathAction(diagnostics, diagnosticCode, document),
   ];
 };

--- a/src/providers/code-actions/sastCodeActions.ts
+++ b/src/providers/code-actions/sastCodeActions.ts
@@ -1,15 +1,12 @@
 import * as vscode from 'vscode';
 import {DiagnosticCode} from '../../services/common';
-import {createIgnorePathAction, createIgnoreRuleAction, createOpenViolationCardAction} from './commonActions';
+import {createOpenViolationCardAction} from './commonActions';
 
 export const createCommandCodeActions = (
-    document: vscode.TextDocument,
     diagnostics: vscode.Diagnostic[],
     diagnosticCode: DiagnosticCode,
 ): vscode.CodeAction[] => {
   return [
     createOpenViolationCardAction(diagnostics, diagnosticCode),
-    createIgnoreRuleAction(diagnostics, diagnosticCode, document),
-    createIgnorePathAction(diagnostics, diagnosticCode, document),
   ];
 };

--- a/src/providers/code-actions/scaCodeActions.ts
+++ b/src/providers/code-actions/scaCodeActions.ts
@@ -1,15 +1,12 @@
 import * as vscode from 'vscode';
 import {DiagnosticCode} from '../../services/common';
-import {createIgnorePathAction, createIgnoreRuleAction, createOpenViolationCardAction} from './commonActions';
+import {createOpenViolationCardAction} from './commonActions';
 
 export const createCommandCodeActions = (
-    document: vscode.TextDocument,
     diagnostics: vscode.Diagnostic[],
     diagnosticCode: DiagnosticCode,
 ): vscode.CodeAction[] => {
   return [
     createOpenViolationCardAction(diagnostics, diagnosticCode),
-    createIgnoreRuleAction(diagnostics, diagnosticCode, document),
-    createIgnorePathAction(diagnostics, diagnosticCode, document),
   ];
 };

--- a/src/providers/code-actions/secretsCodeActions.ts
+++ b/src/providers/code-actions/secretsCodeActions.ts
@@ -1,49 +1,12 @@
 import * as vscode from 'vscode';
 import {DiagnosticCode} from '../../services/common';
-import {VscodeCommands} from '../../utils/commands';
-import {CommandParameters} from '../../cli-wrapper/constants';
-import {IgnoreCommandConfig} from '../../types/commands';
-import {createIgnorePathAction, createIgnoreRuleAction, createOpenViolationCardAction} from './commonActions';
-import {ScanType} from '../../constants';
-
-const createIgnoreValueAction = (
-    diagnostics: vscode.Diagnostic[], range: vscode.Range | vscode.Selection, document: vscode.TextDocument
-): vscode.CodeAction => {
-  const value = document.getText(range);
-
-  const ignoreValueAction = new vscode.CodeAction(
-      `ignore value ${value}`,
-      vscode.CodeActionKind.QuickFix
-  );
-  ignoreValueAction.command = {
-    command: VscodeCommands.IgnoreCommandId,
-    title: `Ignore value: ${value}`,
-    tooltip: 'This will always ignore this value',
-    arguments: [
-      {
-        scanType: ScanType.Secrets,
-        ignoreBy: CommandParameters.ByValue,
-        param: value,
-        filePath: document.fileName,
-      } as IgnoreCommandConfig,
-    ],
-  };
-  ignoreValueAction.diagnostics = diagnostics;
-  ignoreValueAction.isPreferred = true;
-
-  return ignoreValueAction;
-};
+import {createOpenViolationCardAction} from './commonActions';
 
 export const createCommandCodeActions = (
-    document: vscode.TextDocument,
-    range: vscode.Range | vscode.Selection,
     diagnostics: vscode.Diagnostic[],
     diagnosticCode: DiagnosticCode,
 ): vscode.CodeAction[] => {
   return [
     createOpenViolationCardAction(diagnostics, diagnosticCode),
-    createIgnoreValueAction(diagnostics, range, document),
-    createIgnoreRuleAction(diagnostics, diagnosticCode, document),
-    createIgnorePathAction(diagnostics, diagnosticCode, document),
   ];
 };

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -87,7 +87,7 @@ export const finalizeScanState = (state: VscodeStates, success: boolean, progres
 };
 
 export class DiagnosticCode {
-  scanType: string;
+  scanType: ScanType;
   uniqueDetectionId: string;
 
   constructor(scanType: ScanType, uniqueDetectionId: string) {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import {VscodeStates} from './states';
+import {scanResultsService} from '../services/ScanResultsService';
 
 // A module to handle vscode extension context global state
 let extensionContext: vscode.ExtensionContext | null = null;
@@ -25,6 +26,8 @@ export const resetState = () => {
   updateWorkspaceState(VscodeStates.NotificationWasShown, false);
 
   updateWorkspaceState(VscodeStates.HasDetections, false);
+
+  scanResultsService.dropAllScanResults();
 };
 
 export const getContext = (): vscode.ExtensionContext => {


### PR DESCRIPTION
we use detection hash as the suffix of the label to make unique actions (sometimes titles are the same, especially for SCA). pls verify the collision probability 

DEMO:

SAST:
<img width="350" alt="image" src="https://github.com/cycodehq/vscode-extension/assets/15520314/54f01ff6-754f-4942-832c-0e8894e75f1b">

IaC:
<img width="350" alt="image" src="https://github.com/cycodehq/vscode-extension/assets/15520314/090413d5-4fe1-4f2f-aed5-73b127faf0c2">

SCA:
<img width="350" alt="image" src="https://github.com/cycodehq/vscode-extension/assets/15520314/9ae60e4d-9f4d-4127-8847-17c254c9f8c9">

Secrets:
<img width="350" alt="image" src="https://github.com/cycodehq/vscode-extension/assets/15520314/01745846-6b45-4da6-97e8-1bd4fe34fd71">

